### PR TITLE
Prepare guest: Support existing guest VMs with LVM filesystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,6 +317,13 @@ delete *all secrets* from the guest VM (see
 [below](#run-integrity-only-workflow)). SSH keys, instead, are regenerated
 automatically.
 
+Caution: if your VM image uses a [LVM2
+filesystem](https://en.wikipedia.org/wiki/Logical_Volume_Manager_(Linux)), make
+sure that on the host there are no other LVM2 filesystems mounted with the same
+name (you can check with `sudo lvdisplay`). Otherwise, we will not be able to
+extract the guest filesystem when preparing the integrity-protected or encrypted
+volume. Alternatively, you can use the Option A to avoid any potential issues.
+
 ```bash
 # Run VM for configuration
 make run IMAGE=<your_image>


### PR DESCRIPTION
LVM filesystems are a bit tricky to handle.

Before mounting the guest VM, we first need to check if there are other LVM devices currently mounted on the host, to avoid any confusion. However, if there already is a LVM device with the _same_ name as the one of the guest VM, we will not be able to extract the guest's filesystem because it will not be correctly mounted on the host. I added some useful output in case such thing happens.

If, instead, there is another LVM device but with a different name, the assumption is that `lvdisplay` will show the devices in order, so the one belonging to the guest VM will be the last one.